### PR TITLE
Don't inline class="react-pencil undefined" ...

### DIFF
--- a/src/react-pencil.jsx
+++ b/src/react-pencil.jsx
@@ -224,7 +224,7 @@ class ReactPencil extends Component {
     const {multiline, pencil, error, wrapperClassname, onEditDone, ...rest} = this.props;
     const Component = multiline ? Multiline : Singleline;
     return (
-      <div className={`react-pencil ${wrapperClassname} ${error ? 'error' : ''}`}>
+      <div className={`react-pencil${wrapperClassname ? ' ' + wrapperClassname : ''}${error ? ' error' : ''}`}>
         <Component ref='editable' {...rest} finishEdit={this.finishEdit.bind(this)}/>
         {pencil ? this.renderPencilButton() : null}
         {error ? this.renderError(error) : null}


### PR DESCRIPTION
when the wrapperClassname was not set.